### PR TITLE
[add] simulation_interfaces to ros2_java_desktop.repos

### DIFF
--- a/ros2_java_desktop.repos
+++ b/ros2_java_desktop.repos
@@ -31,3 +31,7 @@ repositories:
     type: git
     url: https://github.com/ros2/geometry2.git
     version: humble
+  ros-simulation/simulation_interfaces:
+    type: git
+    url: https://github.com/ros-simulation/simulation_interfaces.git
+    version: main


### PR DESCRIPTION
minecraft_ros2 でsimulation_interfacesに含まれるサービスを利用したいので、リポジトリのリストにsimulation_interfacesを追加しました。