### PR TITLE
Add minecraft_msgs repository to ros2_java_desktop.repos

### DIFF
--- a/ros2_java_desktop.repos
+++ b/ros2_java_desktop.repos
@@ -35,3 +35,7 @@ repositories:
     type: git
     url: https://github.com/ros-simulation/simulation_interfaces.git
     version: main
+  minecraft-ros2/minecraft_msgs:
+    type: git
+    url: https://github.com/minecraft-ros2/minecraft_msgs.git
+    version: humble


### PR DESCRIPTION
https://github.com/minecraft-ros2/minecraft_ros2/pull/33 のエラーがros2_javaのビルドに含まれていないことによるものだったため、その修正です